### PR TITLE
Support ppas.js

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,5 +2,7 @@ homepage: "https://www.piwik.pro/"
 documentation: "https://developers.piwik.pro/en/latest/data_collection/api/http_api.html"
 versions:
   # Latest version
+  - sha: 32f6fd045f54d84c13610311263122f87924fda6
+    changeNotes: Add support for ppas.js loading
   - sha: 5f541d7f3fa49735b74e438c2ae4427a3697f164
     changeNotes: Initial release


### PR DESCRIPTION
I made a refactored version of #4 where instead of duplicating the functions and configurations, the toggle for serveJs automatically allows also ppas.js, and then it's just a question of setting the namespace correctly based on the request path.

Replaces #4 