### PR TITLE
Add support for piwik.php endpoint

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,6 +2,8 @@ homepage: "https://www.piwik.pro/"
 documentation: "https://developers.piwik.pro/en/latest/data_collection/api/http_api.html"
 versions:
   # Latest version
+  - sha: 24376c654b4858b40b90c8d7f3abdd89eb9da967
+    changeNotes: Add support for piwik.php endpoint
   - sha: 32f6fd045f54d84c13610311263122f87924fda6
     changeNotes: Add support for ppas.js loading
   - sha: 5f541d7f3fa49735b74e438c2ae4427a3697f164

--- a/template.tpl
+++ b/template.tpl
@@ -190,6 +190,13 @@ const getPpmsEndpointPath = () => {
   return '/ppms.php';
 };
 
+/**
+ * Returns the path to the piwik.php endpoint.
+ */
+const getPiwikEndpointPath = () => {
+  return '/piwik.php';
+};
+
 /** 
  * Merges the two objects together by preferencing obj2.
  *
@@ -335,11 +342,11 @@ if (REQUEST_PATH === getPpmsFilePath() || REQUEST_PATH === getPpasFilePath()) {
 }
   
 // Check if request is a Piwik PRO event
-if (REQUEST_PATH === getPpmsEndpointPath() && 
+if ((REQUEST_PATH === getPpmsEndpointPath() || REQUEST_PATH === getPiwikEndpointPath()) && 
     VALID_REQUEST_METHODS.indexOf(REQUEST_METHOD) > -1) {
   // Claim the request
   claimRequest();
-  log('ppms.php request claimed');
+  log(REQUEST_PATH + ' request claimed');
   
   const requestString = REQUEST_METHOD === 'GET' ? getRequestQueryString() : getRequestBody();
   let requestData = requestStringToObj(requestString);


### PR DESCRIPTION
This commit adds support for `piwik.php` endpoint, which is an (older) alternative for `ppms.php`. The alternative endpoint is currently used is Piwik PRO mobile SDKs.